### PR TITLE
Add today provider

### DIFF
--- a/lib/data/providers/today_provider.dart
+++ b/lib/data/providers/today_provider.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mona/data/model/date.dart';
+
+class TodayProvider extends ChangeNotifier with WidgetsBindingObserver {
+  Date _today = Date.today();
+  Timer? _dayChangeTimer;
+
+  TodayProvider() {
+    WidgetsBinding.instance.addObserver(this);
+    _scheduleDayChange();
+  }
+
+  Date get today => _today;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _refresh();
+      _scheduleDayChange();
+    } else if (state == AppLifecycleState.paused) {
+      _dayChangeTimer?.cancel();
+    }
+  }
+
+  void _refresh() {
+    final current = Date.today();
+    if (current != _today) {
+      _today = current;
+      notifyListeners();
+    }
+  }
+
+  void _scheduleDayChange() {
+    _dayChangeTimer?.cancel();
+    final now = clock.now();
+    final delay = _nextDayChange(now).difference(now) +
+        const Duration(seconds: 1); // 1 second of slack to avoid race condition
+    _dayChangeTimer = Timer(delay, () {
+      _refresh();
+      _scheduleDayChange();
+    });
+  }
+
+  DateTime _nextDayChange(DateTime now) {
+    final startHour = logicalDayStartMinutes ~/ 60;
+    final startMinute = logicalDayStartMinutes % 60;
+    final dayChange =
+        DateTime(now.year, now.month, now.day, startHour, startMinute);
+    return dayChange.isAfter(now)
+        ? dayChange
+        : dayChange.add(const Duration(days: 1));
+  }
+
+  @override
+  void dispose() {
+    _dayChangeTimer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:mona/data/providers/blood_test_provider.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/data/providers/medication_schedule_provider.dart';
 import 'package:mona/data/providers/supply_item_provider.dart';
+import 'package:mona/data/providers/today_provider.dart';
 import 'package:mona/i18n/locale_provider.dart';
 import 'package:mona/services/preferences_service.dart';
 import 'package:mona/theme/app_theme_controller.dart';
@@ -52,6 +53,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => MedicationIntakeProvider()),
         ChangeNotifierProvider(create: (_) => MedicationScheduleProvider()),
         ChangeNotifierProvider(create: (_) => BloodTestProvider()),
+        ChangeNotifierProvider(create: (_) => TodayProvider(), lazy: false),
         ChangeNotifierProvider.value(value: preferencesService),
         ChangeNotifierProvider(
             create: (_) => AppThemeProvider(preferencesService)),

--- a/lib/ui/views/home/home_page.dart
+++ b/lib/ui/views/home/home_page.dart
@@ -7,6 +7,7 @@ import 'package:mona/data/model/date.dart';
 import 'package:mona/data/model/intake_slot.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
 import 'package:mona/data/providers/medication_schedule_provider.dart';
+import 'package:mona/data/providers/today_provider.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/translations.g.dart';
 import 'package:mona/ui/constants/dimensions.dart';
@@ -20,6 +21,7 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    context.watch<TodayProvider>(); // needed for the titles and intake cards
     final scheduleProvider = context.watch<MedicationScheduleProvider>();
     final intakeProvider = context.watch<MedicationIntakeProvider>();
 

--- a/lib/ui/views/intakes/intakes_page.dart
+++ b/lib/ui/views/intakes/intakes_page.dart
@@ -4,6 +4,7 @@ import 'package:m3e_core/m3e_core.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:mona/data/model/medication_intake.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/data/providers/today_provider.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/helpers/medication_intake_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
@@ -18,6 +19,7 @@ import 'package:provider/provider.dart';
 class IntakesPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    context.watch<TodayProvider>(); // needed for the hrt counter widget
     final preferencesService = context.watch<PreferencesService>();
 
     return Consumer<MedicationIntakeProvider>(

--- a/lib/ui/views/levels/levels_page/levels_page.dart
+++ b/lib/ui/views/levels/levels_page/levels_page.dart
@@ -8,7 +8,6 @@ import 'package:mona/data/model/hormone.dart';
 import 'package:mona/data/model/level_entry.dart';
 import 'package:mona/data/providers/blood_test_provider.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
-import 'package:mona/data/providers/today_provider.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/helpers/units_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
@@ -29,7 +28,6 @@ class LevelsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    context.watch<TodayProvider>(); // needed for the graph tile
     final colorScheme = Theme.of(context).colorScheme;
 
     return Consumer3<MedicationIntakeProvider, BloodTestProvider,

--- a/lib/ui/views/levels/levels_page/levels_page.dart
+++ b/lib/ui/views/levels/levels_page/levels_page.dart
@@ -8,6 +8,7 @@ import 'package:mona/data/model/hormone.dart';
 import 'package:mona/data/model/level_entry.dart';
 import 'package:mona/data/providers/blood_test_provider.dart';
 import 'package:mona/data/providers/medication_intake_provider.dart';
+import 'package:mona/data/providers/today_provider.dart';
 import 'package:mona/i18n/build_context_extensions.dart';
 import 'package:mona/i18n/helpers/units_l10n.dart';
 import 'package:mona/i18n/translations.g.dart';
@@ -27,6 +28,7 @@ class LevelsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    context.watch<TodayProvider>(); // needed for the graph tile
     final colorScheme = Theme.of(context).colorScheme;
 
     return Consumer3<MedicationIntakeProvider, BloodTestProvider,

--- a/lib/ui/views/levels/levels_page/levels_page.dart
+++ b/lib/ui/views/levels/levels_page/levels_page.dart
@@ -20,6 +20,7 @@ import 'package:mona/ui/views/levels/levels_page/baby_bar_chart_graph.dart';
 import 'package:mona/ui/views/levels/levels_page/baby_main_chart_graph.dart';
 import 'package:mona/ui/views/levels/main_graph_page/chart_page.dart';
 import 'package:mona/ui/widgets/main_page_wrapper.dart';
+import 'package:mona/ui/widgets/minute_ticker.dart';
 import 'package:mona/util/time_difference.dart';
 import 'package:provider/provider.dart';
 
@@ -115,9 +116,14 @@ class LevelsPage extends StatelessWidget {
   }
 }
 
-class _GraphTile extends StatelessWidget {
+class _GraphTile extends StatefulWidget {
   const _GraphTile();
 
+  @override
+  State<_GraphTile> createState() => _GraphTileState();
+}
+
+class _GraphTileState extends State<_GraphTile> with MinuteTicker {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);

--- a/lib/ui/views/levels/main_graph_page/chart_page.dart
+++ b/lib/ui/views/levels/main_graph_page/chart_page.dart
@@ -4,6 +4,7 @@ import 'package:mona/i18n/translations.g.dart';
 import 'package:mona/ui/views/levels/main_graph_page/chart_graph.dart';
 import 'package:mona/ui/views/levels/main_graph_page/chart_slider.dart';
 import 'package:mona/ui/widgets/main_page_wrapper.dart';
+import 'package:mona/ui/widgets/minute_ticker.dart';
 import 'package:provider/provider.dart';
 
 class ChartPage extends StatefulWidget {
@@ -11,7 +12,7 @@ class ChartPage extends StatefulWidget {
   State<ChartPage> createState() => _ChartPageState();
 }
 
-class _ChartPageState extends State<ChartPage> {
+class _ChartPageState extends State<ChartPage> with MinuteTicker {
   double sliderValue = 0;
 
   @override

--- a/lib/ui/widgets/minute_ticker.dart
+++ b/lib/ui/widgets/minute_ticker.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+mixin MinuteTicker<T extends StatefulWidget> on State<T> {
+  Timer? _minuteTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _minuteTimer = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _minuteTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/test/data/providers/today_provider_test.dart
+++ b/test/data/providers/today_provider_test.dart
@@ -1,0 +1,84 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/data/model/date.dart';
+import 'package:mona/data/providers/today_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('today is the current logical day at construction', () {
+    // Arrange
+    final now = DateTime(2026, 6, 1, 12, 0);
+    withClock(Clock(() => now), () {
+      // Act
+      final provider = TodayProvider();
+      // Assert
+      expect(provider.today, Date(year: 2026, month: 6, day: 1));
+      provider.dispose();
+    });
+  });
+
+  group('on resume', () {
+    final cases = [
+      (
+        name: 'updates today when the day has changed',
+        resumeAt: DateTime(2026, 6, 2, 12, 0),
+        expected: Date(year: 2026, month: 6, day: 2),
+      ),
+      (
+        name: 'keeps today when still the same day',
+        resumeAt: DateTime(2026, 6, 1, 18, 0),
+        expected: Date(year: 2026, month: 6, day: 1),
+      ),
+    ];
+
+    for (final c in cases) {
+      test(c.name, () {
+        // Arrange
+        var now = DateTime(2026, 6, 1, 12, 0);
+        withClock(Clock(() => now), () {
+          final provider = TodayProvider();
+          // Act
+          now = c.resumeAt;
+          provider.didChangeAppLifecycleState(AppLifecycleState.resumed);
+          // Assert
+          expect(provider.today, c.expected);
+          provider.dispose();
+        });
+      });
+    }
+  });
+
+  test('notifies listeners when the day changes on resume', () {
+    // Arrange
+    var now = DateTime(2026, 6, 1, 12, 0);
+    withClock(Clock(() => now), () {
+      final provider = TodayProvider();
+      var notifications = 0;
+      provider.addListener(() => notifications++);
+      // Act
+      now = DateTime(2026, 6, 2, 12, 0);
+      provider.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      // Assert
+      expect(notifications, 1);
+      provider.dispose();
+    });
+  });
+
+  test('does not notify when the day is the same on resume', () {
+    // Arrange
+    var now = DateTime(2026, 6, 1, 12, 0);
+    withClock(Clock(() => now), () {
+      final provider = TodayProvider();
+      var notifications = 0;
+      provider.addListener(() => notifications++);
+      // Act
+      now = DateTime(2026, 6, 1, 18, 0);
+      provider.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      // Assert
+      expect(notifications, 0);
+      provider.dispose();
+    });
+  });
+}

--- a/test/ui/widgets/minute_ticker_test.dart
+++ b/test/ui/widgets/minute_ticker_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mona/ui/widgets/minute_ticker.dart';
+
+class _TickerHost extends StatefulWidget {
+  const _TickerHost({required this.onBuild});
+
+  final VoidCallback onBuild;
+
+  @override
+  State<_TickerHost> createState() => _TickerHostState();
+}
+
+class _TickerHostState extends State<_TickerHost> with MinuteTicker {
+  @override
+  Widget build(BuildContext context) {
+    widget.onBuild();
+    return const SizedBox.shrink();
+  }
+}
+
+void main() {
+  testWidgets('rebuilds after a minute passes', (tester) async {
+    // Arrange
+    var builds = 0;
+    await tester.pumpWidget(_TickerHost(onBuild: () => builds++));
+    final initial = builds;
+
+    // Act
+    await tester.pump(const Duration(minutes: 1));
+
+    // Assert
+    expect(builds, initial + 1);
+  });
+}


### PR DESCRIPTION
### Description
adds a change notifier that holds today value. it refreshes on a day change and when the app is resumed.
used on every page that doesn't refresh automatically when the day changes.
also refreshes graphs every minute while im at it.

Related to issue: #343 

### Type of change
- Bug fix (non-breaking change which fixes an issue)